### PR TITLE
Fix sed compatibility

### DIFF
--- a/bin/generate-init.sh
+++ b/bin/generate-init.sh
@@ -2,6 +2,15 @@
 
 set -e
 
+# cross-platform sed -i wrapper
+sedi() {
+  if sed --version >/dev/null 2>&1; then
+    sed -i "$@"
+  else
+    sed -i '' "$@"
+  fi
+}
+
 # スクリプトの絶対パスを取得
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
@@ -26,7 +35,7 @@ echo "Generating $DEV_OUTPUT_FILE from $DEV_TEMPLATE_FILE using $ENV_FILE..."
 # .envファイルの改行コードを変換（必要に応じて）
 if command -v dos2unix >/dev/null 2>&1; then
   dos2unix "$ENV_FILE"
-  sed -i '1s/^\xEF\xBB\xBF//' "$ENV_FILE"
+  sedi '1s/^\xEF\xBB\xBF//' "$ENV_FILE"
 fi
 
 # 環境変数を読み込む
@@ -41,8 +50,8 @@ cp "$DEV_TEMPLATE_FILE" "$DEV_OUTPUT_FILE"
 # 環境変数を置換
 for var in POSTGRES_DB DEV_DB DEV_USER DEV_PASSWORD APP_USER APP_PASSWORD; do
   if [ -n "${!var}" ]; then
-    sed -i "s/\${$var}/${!var}/g" "$OUTPUT_FILE"
-    sed -i "s/\${$var}/${!var}/g" "$DEV_OUTPUT_FILE"
+    sedi "s/\${$var}/${!var}/g" "$OUTPUT_FILE"
+    sedi "s/\${$var}/${!var}/g" "$DEV_OUTPUT_FILE"
   else
     echo "Warning: $var is not set"
   fi

--- a/bin/git_bump.sh
+++ b/bin/git_bump.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# cross-platform sed -i wrapper
+sedi() {
+  if sed --version >/dev/null 2>&1; then
+    sed -i "$@"
+  else
+    sed -i '' "$@"
+  fi
+}
 # File Version: v2.3.0
 # Project Version: v2.3.0
 # Last Updated: 2025-07-02
@@ -86,12 +94,12 @@ for file in "${VERSION_FILES[@]}"; do
         else
           NEXT_FILE_VERSION=$NEXT_VERSION
         fi
-        sed -i "s/file_version: v[0-9]\+\.[0-9]\+\.[0-9]\+/file_version: v$NEXT_FILE_VERSION/" "$file"
-        sed -i "s/project_version: v[0-9]\+\.[0-9]\+\.[0-9]\+/project_version: v$NEXT_VERSION/" "$file"
-        sed -i "s/last_updated: [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}/last_updated: $TODAY/" "$file"
-        sed -i "s/File Version: v[0-9]\+\.[0-9]\+\.[0-9]\+/File Version: v$NEXT_FILE_VERSION/" "$file"
-        sed -i "s/Project Version: v[0-9]\+\.[0-9]\+\.[0-9]\+/Project Version: v$NEXT_VERSION/" "$file"
-        sed -i "s/Last Updated: [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}/Last Updated: $TODAY/" "$file"
+        sedi "s/file_version: v[0-9]\+\.[0-9]\+\.[0-9]\+/file_version: v$NEXT_FILE_VERSION/" "$file"
+        sedi "s/project_version: v[0-9]\+\.[0-9]\+\.[0-9]\+/project_version: v$NEXT_VERSION/" "$file"
+        sedi "s/last_updated: [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}/last_updated: $TODAY/" "$file"
+        sedi "s/File Version: v[0-9]\+\.[0-9]\+\.[0-9]\+/File Version: v$NEXT_FILE_VERSION/" "$file"
+        sedi "s/Project Version: v[0-9]\+\.[0-9]\+\.[0-9]\+/Project Version: v$NEXT_VERSION/" "$file"
+        sedi "s/Last Updated: [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}/Last Updated: $TODAY/" "$file"
         ;;
       *.py|*.sh)
         # Python/Shellファイルの更新
@@ -102,9 +110,9 @@ for file in "${VERSION_FILES[@]}"; do
         else
           NEXT_FILE_VERSION=$NEXT_VERSION
         fi
-        sed -i "s/File Version: v[0-9]\+\.[0-9]\+\.[0-9]\+/File Version: v$NEXT_FILE_VERSION/" "$file"
-        sed -i "s/Project Version: v[0-9]\+\.[0-9]\+\.[0-9]\+/Project Version: v$NEXT_VERSION/" "$file"
-        sed -i "s/Last Updated: [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}/Last Updated: $TODAY/" "$file"
+        sedi "s/File Version: v[0-9]\+\.[0-9]\+\.[0-9]\+/File Version: v$NEXT_FILE_VERSION/" "$file"
+        sedi "s/Project Version: v[0-9]\+\.[0-9]\+\.[0-9]\+/Project Version: v$NEXT_VERSION/" "$file"
+        sedi "s/Last Updated: [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}/Last Updated: $TODAY/" "$file"
         ;;
       *.json)
         # JSONファイルの更新
@@ -115,9 +123,9 @@ for file in "${VERSION_FILES[@]}"; do
         else
           NEXT_FILE_VERSION=$NEXT_VERSION
         fi
-        sed -i "s/File Version: v[0-9]\+\.[0-9]\+\.[0-9]\+/File Version: v$NEXT_FILE_VERSION/" "$file"
-        sed -i "s/Project Version: v[0-9]\+\.[0-9]\+\.[0-9]\+/Project Version: v$NEXT_VERSION/" "$file"
-        sed -i "s/Last Updated: [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}/Last Updated: $TODAY/" "$file"
+        sedi "s/File Version: v[0-9]\+\.[0-9]\+\.[0-9]\+/File Version: v$NEXT_FILE_VERSION/" "$file"
+        sedi "s/Project Version: v[0-9]\+\.[0-9]\+\.[0-9]\+/Project Version: v$NEXT_VERSION/" "$file"
+        sedi "s/Last Updated: [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}/Last Updated: $TODAY/" "$file"
         ;;
       project_version.txt)
         # project_version.txtの更新


### PR DESCRIPTION
## Summary
- add cross-platform sed wrapper
- use the wrapper in scripts to work on Linux and macOS

## Testing
- `pytest -q` *(fails: Unicode decode error in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6865deb694f8832e95ec8a6bbb42b3f3